### PR TITLE
Improve focus accessibility on navigation section toggle icons

### DIFF
--- a/navigation/src/mobile.css
+++ b/navigation/src/mobile.css
@@ -16,7 +16,8 @@ body.menu-toggled-open {
 	width: 100%;
 }
 
-#nav a {
+#nav a,
+#nav .submenu-toggle {
 	color: #fff;
 }
 


### PR DESCRIPTION
The focus outline color is inherited from the text color in Firefox.